### PR TITLE
Fix Conda CI workflow and add environment.yml

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -10,25 +10,41 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up Miniconda
+      uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+        python-version: "3.10"
+        auto-activate-base: true
+        activate-environment: base
+
     - name: Install dependencies
+      shell: bash -el {0}
       run: |
-        conda env update --file environment.yml --name base
+        if [ -f environment.yml ]; then
+          echo "Found environment.yml — updating conda environment"
+          if command -v mamba >/dev/null 2>&1; then
+            mamba env update --file environment.yml --name base
+          else
+            conda env update --file environment.yml --name base
+          fi
+        elif [ -f requirements.txt ]; then
+          echo "No environment.yml found — falling back to pip install"
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+        else
+          echo "No environment.yml or requirements.txt found — aborting"
+          exit 1
+        fi
+
     - name: Lint with flake8
+      shell: bash -el {0}
       run: |
-        conda install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test with pytest
+      shell: bash -el {0}
       run: |
-        conda install pytest
         pytest

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: frp-freedom
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pytest
+  - flake8
+  - pip
+  - pip:
+    - -r requirements.txt


### PR DESCRIPTION
This change fixes the failing CI job at the "Install dependencies" step. The failure was caused by a missing `environment.yml` file which the workflow was trying to use.

I have implemented the following:
1. Created a canonical `environment.yml` at the repository root containing the necessary dependencies (Python 3.10, pytest, flake8) and linking to `requirements.txt`.
2. Updated the GitHub Actions workflow `python-package-conda.yml` to use the official `conda-incubator/setup-miniconda@v3` action, which is more reliable than manual path manipulation.
3. Replaced the "Install dependencies" step with a robust script that checks for `environment.yml` before trying to use it, falling back to `requirements.txt` if needed.
4. Cleaned up the workflow by removing redundant `conda install` commands for `flake8` and `pytest`, as these are now managed within the environment creation/update step.
5. Added `shell: bash -el {0}` to relevant steps to ensure the Conda environment is correctly activated.

---
*PR created automatically by Jules for task [10826582547218783211](https://jules.google.com/task/10826582547218783211) started by @youngrichu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and test infrastructure with updated dependency management.
  * Enhanced continuous integration workflow configuration for more reliable project builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->