### PR TITLE
Fix main window device refresh and info display

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -614,34 +614,70 @@ Proceed only if you understand the risks and legal implications.
     
     def refresh_devices(self):
         """Refresh device list"""
-        try:
-            self.device_manager.refresh_devices()
-            if hasattr(self, 'device_frame'):
-                self.device_frame.refresh()
-            messagebox.showinfo("Refresh Complete", "Device list refreshed successfully.")
-        except Exception as e:
-            messagebox.showerror("Refresh Error", f"Failed to refresh devices: {e}")
-    
+        def run_refresh():
+            try:
+                devices = self.device_manager.scan_devices()
+                self.root.after(0, self._complete_device_refresh, devices)
+            except Exception as e:
+                self.root.after(0, lambda: messagebox.showerror("Refresh Error", f"Failed to refresh devices: {e}"))
+
+        threading.Thread(target=run_refresh, daemon=True).start()
+
+    def _complete_device_refresh(self, devices):
+        """Apply refreshed device data to the current UI state."""
+        if hasattr(self, 'device_frame') and self.device_frame:
+            try:
+                if self.device_frame.winfo_exists():
+                    self.device_frame.update_device_list(devices)
+            except (tk.TclError, AttributeError):
+                pass
+
+        if self.selected_device:
+            refreshed_device = next(
+                (device for device in devices if device.serial == self.selected_device.serial),
+                None
+            )
+            if refreshed_device:
+                self.selected_device = refreshed_device
+
+        messagebox.showinfo("Refresh Complete", "Device list refreshed successfully.")
+
+    @staticmethod
+    def _format_device_value(value: Any) -> str:
+        """Render device fields consistently for the info dialog."""
+        if value is None:
+            return "Unknown"
+
+        if isinstance(value, str):
+            value = value.strip()
+            return value or "Unknown"
+
+        return str(value)
+
+    @classmethod
+    def format_device_info_text(cls, device: DeviceInfo) -> str:
+        """Format device details using the current DeviceInfo schema."""
+        return f"""
+Device Information:
+
+Model: {cls._format_device_value(device.model)}
+Manufacturer: {cls._format_device_value(device.manufacturer)}
+Serial Number: {cls._format_device_value(device.serial)}
+Android Version: {cls._format_device_value(device.android_version)}
+API Level: {cls._format_device_value(getattr(device, 'api_level', None))}
+Security Patch: {cls._format_device_value(getattr(device, 'security_patch', None))}
+Build ID: {cls._format_device_value(getattr(device, 'build_id', None))}
+Connection Type: {cls._format_device_value(device.connection_type)}
+FRP Status: {cls._format_device_value(getattr(device, 'frp_status', None))}
+""".strip()
+
     def show_device_info(self):
         """Show detailed device information"""
         if not self.selected_device:
             messagebox.showwarning("No Device", "Please select a device first.")
             return
-        
-        info_text = f"""
-Device Information:
 
-Model: {self.selected_device.model}
-Manufacturer: {self.selected_device.manufacturer}
-Serial Number: {self.selected_device.serial}
-Android Version: {self.selected_device.android_version}
-API Level: {self.selected_device.api_level}
-Security Patch: {getattr(self.selected_device, 'security_patch', 'Unknown')}
-Build Number: {getattr(self.selected_device, 'build_number', 'Unknown')}
-Connection Type: {self.selected_device.connection_type}
-Status: {self.selected_device.status}
-"""
-        
+        info_text = self.format_device_info_text(self.selected_device)
         messagebox.showinfo("Device Information", info_text)
     
     def show_settings(self):

--- a/tests/test_main_window_device_info.py
+++ b/tests/test_main_window_device_info.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock, patch
+
+from src.core.device_manager import DeviceInfo
+from src.gui.main_window import FRPFreedomApp
+
+
+def make_device(**overrides):
+    device = DeviceInfo(
+        serial="serial-001",
+        model="Galaxy S21",
+        manufacturer="Samsung",
+        android_version="14",
+        sdk_version="34",
+        bootloader_version="boot-v1",
+        frp_status="locked",
+        connection_type="adb",
+    )
+
+    for key, value in overrides.items():
+        setattr(device, key, value)
+
+    return device
+
+
+def test_format_device_info_text_uses_current_deviceinfo_fields():
+    device = make_device(
+        api_level="34",
+        security_patch="2025-01-05",
+        build_id="UP1A.231005.007",
+    )
+
+    info_text = FRPFreedomApp.format_device_info_text(device)
+
+    assert "Model: Galaxy S21" in info_text
+    assert "Manufacturer: Samsung" in info_text
+    assert "Build ID: UP1A.231005.007" in info_text
+    assert "FRP Status: locked" in info_text
+    assert "Build Number" not in info_text
+    assert "\nStatus:" not in f"\n{info_text}"
+
+
+def test_format_device_info_text_uses_unknown_for_blank_optional_fields():
+    device = make_device(
+        manufacturer="",
+        api_level="",
+        security_patch="",
+        build_id="",
+        frp_status="",
+    )
+
+    info_text = FRPFreedomApp.format_device_info_text(device)
+
+    assert "Manufacturer: Unknown" in info_text
+    assert "API Level: Unknown" in info_text
+    assert "Security Patch: Unknown" in info_text
+    assert "Build ID: Unknown" in info_text
+    assert "FRP Status: Unknown" in info_text
+
+
+def test_refresh_devices_uses_scan_devices_and_updates_selected_device():
+    original_device = make_device(serial="serial-001", model="Old Model")
+    refreshed_device = make_device(serial="serial-001", model="New Model")
+    scanned_devices = [refreshed_device]
+
+    app = FRPFreedomApp.__new__(FRPFreedomApp)
+    app.device_manager = Mock()
+    app.device_manager.scan_devices.return_value = scanned_devices
+    app.selected_device = original_device
+    app.root = Mock()
+    app.root.after.side_effect = lambda _delay, callback, *args: callback(*args)
+
+    app.device_frame = Mock()
+    app.device_frame.winfo_exists.return_value = True
+
+    class ImmediateThread:
+        def __init__(self, target, daemon):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    with patch("src.gui.main_window.threading.Thread", ImmediateThread), patch(
+        "src.gui.main_window.messagebox.showinfo"
+    ) as showinfo:
+        app.refresh_devices()
+
+    app.device_manager.scan_devices.assert_called_once_with()
+    app.device_frame.update_device_list.assert_called_once_with(scanned_devices)
+    assert app.selected_device is refreshed_device
+    showinfo.assert_called_once_with("Refresh Complete", "Device list refreshed successfully.")


### PR DESCRIPTION
### Summary

This PR fixes stale GUI/backend wiring in the main window.

Changes made:
- Updated the manual refresh path to call `DeviceManager.scan_devices()` instead of the nonexistent `refresh_devices()`.
- Updated the device-info dialog to use the actual `DeviceInfo` schema.
- Replaced `build_number` with `build_id`.
- Removed the nonexistent `status` field from the popup.
- Added fallback display of `Unknown` only for missing or blank values.
- Added regression coverage for device-info formatting and refresh behavior.

### Verification

```bash
python -m pytest
python -m compileall -q .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device refresh now operates in the background for improved responsiveness.
  * Enhanced device information display with improved formatting and additional fields.

* **Bug Fixes**
  * Improved error handling and messaging for device refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->