### PR TITLE
Fix undefined name 'e' in main_window.py callback

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -619,7 +619,7 @@ Proceed only if you understand the risks and legal implications.
                 devices = self.device_manager.scan_devices()
                 self.root.after(0, self._complete_device_refresh, devices)
             except Exception as e:
-                self.root.after(0, lambda: messagebox.showerror("Refresh Error", f"Failed to refresh devices: {e}"))
+                self.root.after(0, lambda e=e: messagebox.showerror("Refresh Error", f"Failed to refresh devices: {e}"))
 
         threading.Thread(target=run_refresh, daemon=True).start()
 


### PR DESCRIPTION
Fixed a flake8 F821 (undefined name 'e') error in `src/gui/main_window.py` by capturing the exception in the lambda's default parameter. This ensures the exception object is available when the callback runs later. Verified the fix with linting and unit tests.

---
*PR created automatically by Jules for task [1961040243664794150](https://jules.google.com/task/1961040243664794150) started by @youngrichu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device refresh error handling so error dialogs reliably show the correct exception when a background refresh fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->