### PR TITLE
Fix syntax error in refresh_devices lambda

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -619,7 +619,7 @@ Proceed only if you understand the risks and legal implications.
                 devices = self.device_manager.scan_devices()
                 self.root.after(0, self._complete_device_refresh, devices)
             except Exception as e:
-                self.root.after(0, lambda: messagebox.showerror("Refresh Error", f"Failed to refresh devices: {e}"))
+                self.root.after(0, lambda err=e: messagebox.showerror("Refresh Error", f"Failed to refresh devices: {err}"))
 
         threading.Thread(target=run_refresh, daemon=True).start()
 


### PR DESCRIPTION
Fixed a `NameError` in `src/gui/main_window.py` where the exception variable `e` was being used in a lambda function after it had been cleared from scope. The fix uses a default parameter in the lambda function to capture the exception value at definition time. Additionally, I audited the codebase for similar issues and verified that other instances correctly use local variables or default parameters to avoid late-binding closure bugs. All tests passed.

---
*PR created automatically by Jules for task [10507205473028137012](https://jules.google.com/task/10507205473028137012) started by @youngrichu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during device refresh so failure messages now display correctly when a refresh operation throws an exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->